### PR TITLE
PILOT-2668: Add support for exporting user-selected identifiers

### DIFF
--- a/modules/server-filter/export/export-file.js
+++ b/modules/server-filter/export/export-file.js
@@ -123,7 +123,7 @@ export function downloader(project_info) {
       const { params } = req.body;
       const requestHeaders = {
         ...req.headers,
-        Authorization: `Bearer ${process.env.STORYBOOK_TOKEN}`,
+        Authorization: `Bearer ${req.headers.authorization}`,
       };
       const { output, responseFileName, contentType } = await dataStream({
         project_info,

--- a/modules/server-filter/export/utils/authFilterDownload.js
+++ b/modules/server-filter/export/utils/authFilterDownload.js
@@ -30,7 +30,7 @@ export function arrangerAuthFilterDownload(params, sqon, header) {
   const data = fs.readFileSync(`./auth/${role_filter}.json`, 'utf8');
   const filtered = JSON.parse(data);
 
-  // update project_id
+	// update project_id
   filtered['content'][0]['content']['value'] = [project_code];
 
   // add user-selected identifiers
@@ -45,8 +45,8 @@ export function arrangerAuthFilterDownload(params, sqon, header) {
       }
     for (const id of params['identifiers']){
       sqon_id.content.value.push(id)
-      filtered.content.push(sqon_id)
     }
+    filtered.content.push(sqon_id)
   }
 
   // update parent_path based on role

--- a/modules/server-filter/export/utils/getAllData.js
+++ b/modules/server-filter/export/utils/getAllData.js
@@ -58,7 +58,7 @@ export async function getAllData ({
   const nestedFields = extended.filter(({ type }) => type === 'nested').map(({ field }) => field);
 
   const es_schema = project_info.arranger_schema['schema']
-  sqon = arrangerAuthFilterDownload(params['project_code'], sqon, headers)
+  sqon = arrangerAuthFilterDownload(params, sqon, headers)
   const query = buildQuery({ nestedFields, filters: sqon });
 
   runQuery({


### PR DESCRIPTION
## Summary

- Replaced `STORYBOOK_TOKEN` env variable for authorization token in request header for `/download` endpoint.
- Added support for SQON filtering by `identifier` for `/download` endpoint, which are obtained by request body. This allows users to export selected items in the faceted search interface.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-2668

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

- Users should be able to select specific items that they would like to export in the faceted search interface. The resulting TSV downloaded will only include the selected items.