### PR TITLE
PILOT-2680: Update download endpoint to accept JSON body

### DIFF
--- a/modules/server-filter/config.js
+++ b/modules/server-filter/config.js
@@ -1,5 +1,5 @@
 export const SERVER_PORT = process.env.SERVER_PORT || 5051;
-export const ARRANGER_PROJECT_ID = process.env.ARRANGER_PROJECT_ID || 'm2facet';
+export const ARRANGER_PROJECT_ID = process.env.ARRANGER_PROJECT_ID || 'pilotdev';
 export const ELASTICSEARCH = process.env.ELASTICSEARCH || 'http://127.0.0.1:9200';
 
 export const DOWNLOAD_STREAM_BUFFER_SIZE = process.env.DOWNLOAD_STREAM_BUFFER_SIZE || 2000;

--- a/modules/server-filter/export/export-file.js
+++ b/modules/server-filter/export/export-file.js
@@ -116,20 +116,20 @@ export const dataStream = async ({ project_info, headers, ctx, params }) => {
 export function downloader(project_info) {
   const router = express.Router();
 
-  router.use(express.urlencoded({ extended: true }));
+  router.use(express.json());
 
   router.post('/', async function (req, res) {
     try {
-      const { params } = req.body;
+      const data = req.body;
       const requestHeaders = {
         ...req.headers,
-        Authorization: `Bearer ${req.headers.authorization}`,
+        Authorization: req.headers.authorization,
       };
       const { output, responseFileName, contentType } = await dataStream({
         project_info,
         headers: requestHeaders,
         ctx: req.context,
-        params: JSON.parse(params),
+        params: data,
       });
 
       res.set('Content-Type', contentType);


### PR DESCRIPTION
## Summary

- Updated the `/download` endpoint to accept a JSON body, in replacement of  `x-www-form-urlencoded`.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-2680

## Type of Change

Please delete options that are not relevant.

- [X] Refactoring

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

- User should be able to export the faceted search result table into a TSV (including selected identifiers).