### PR TITLE
PILOT-2735: Add CORS header to response

### DIFF
--- a/modules/server-filter/package.json
+++ b/modules/server-filter/package.json
@@ -15,6 +15,7 @@
     "@types/express-serve-static-core": "4.17.24",
     "apollo-server-express": "^2.14.2",
     "axios": "^1.3.4",
+    "cors": "^2.8.5",
     "date-fns": "^2.29.2",
     "express": "^4.18.2",
     "graphql": "^14.5.3",

--- a/modules/server-filter/server.js
+++ b/modules/server-filter/server.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import cors from 'cors';
 import { Client } from '@elastic/elasticsearch';
 import { ApolloServer } from 'apollo-server-express';
 import { downloader } from './export/export-file.js';
@@ -92,7 +93,12 @@ const server = new ApolloServer({
 // Setup express server
 const app = express();
 app.use(express.json()); // support json encoded bodies
+
+// Use serverFilter for incoming requests
 app.use(serverFilter)
+
+// Enable all CORS requests
+app.use(cors())
 
 // Add Arranger middleware
 server.applyMiddleware({


### PR DESCRIPTION
## Summary

- Added CORS header (*) to response to prevent cross-origin error by front-end.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-2735

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

- Calling the `/download` endpoint will no longer return cross-origin error by front-end.