### PR TITLE
PILOT-2593: Replace deprecated github actions and commands

### DIFF
--- a/.github/workflows/build-and-publish-admin-server.yml
+++ b/.github/workflows/build-and-publish-admin-server.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Extract Branch Name
         id: extract_branch
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
   get-version:
     runs-on: ubuntu-20.04
     outputs:
       app_version: ${{steps.get-version.outputs.app_version}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get Version
         id: get-version
         shell: bash
@@ -34,12 +34,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to Github Packages
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: pilotdataplatform.azurecr.io
           username: ${{ secrets.ACR_CLIENT }}
@@ -59,7 +59,7 @@ jobs:
 #      - name: Image digest
 #        run: echo ${{ steps.meta.outputs.tags }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           # relative path to the place where source code with Dockerfile is located
           context: .

--- a/.github/workflows/build-and-publish-admin-ui.yml
+++ b/.github/workflows/build-and-publish-admin-ui.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Extract Branch Name
         id: extract_branch
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
   get-version:
     runs-on: ubuntu-20.04
     outputs:
       app_version: ${{steps.get-version.outputs.app_version}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get Version
         id: get-version
         shell: bash
@@ -34,12 +34,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to Github Packages
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: pilotdataplatform.azurecr.io
           username: ${{ secrets.ACR_CLIENT }}
@@ -59,7 +59,7 @@ jobs:
 #      - name: Image digest
 #        run: echo ${{ steps.meta.outputs.tags }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           # relative path to the place where source code with Dockerfile is located
           context: .

--- a/.github/workflows/build-and-publish-server-filter.yml
+++ b/.github/workflows/build-and-publish-server-filter.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Extract Branch Name
         id: extract_branch
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
   get-version:
     runs-on: ubuntu-20.04
     outputs:
       app_version: ${{steps.get-version.outputs.app_version}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get Version
         id: get-version
         shell: bash
@@ -34,12 +34,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to Github Packages
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: pilotdataplatform.azurecr.io
           username: ${{ secrets.ACR_CLIENT }}
@@ -59,7 +59,7 @@ jobs:
 #      - name: Image digest
 #        run: echo ${{ steps.meta.outputs.tags }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           # relative path to the place where source code with Dockerfile is located
           context: .


### PR DESCRIPTION
## Summary

Address deprecation warnings for certain Github commands and actions

## JIRA Issues

PILOT-2593

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

Run all workflows. There should be no warnings for that run or any succeeding run (Jenkins warning is considered out-of-scope for now pending work on PILOT-2909)
