### PR TITLE
Add facet selections to download filter

### DIFF
--- a/modules/server-filter/export/utils/authFilterDownload.js
+++ b/modules/server-filter/export/utils/authFilterDownload.js
@@ -20,6 +20,12 @@ export function arrangerAuthFilterDownload(req, params, sqon) {
             }
             req.sqon.content.push(sqon_id)
         }
+
+        // add facet selections to sqon
+        for (const filter of sqon.content){
+            req.sqon.content.push(filter)
+        }
+
         // return custom sqon
         return req.sqon
 


### PR DESCRIPTION
## Summary

- Enable facet selections to be added to SQON for `/download` endpoint. This ensures the correct metadata is downloaded when facets are also selected.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-3069

## Type of Change

- [X] Bug fix

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

- Metadata that is downloaded should also reflect the facets that are selected.
