### PR TITLE
PILOT-3069: Update download endpoint to check sqon existence

### DIFF
--- a/modules/server-filter/export/utils/authFilterDownload.js
+++ b/modules/server-filter/export/utils/authFilterDownload.js
@@ -20,10 +20,15 @@ export function arrangerAuthFilterDownload(req, params, sqon) {
             }
             req.sqon.content.push(sqon_id)
         }
+        if (sqon !== null) {
+            if (sqon.content){
+                // add facet selections to sqon
+                for (const filter of sqon.content){
+                    req.sqon.content.push(filter)
 
-        // add facet selections to sqon
-        for (const filter of sqon.content){
-            req.sqon.content.push(filter)
+                }
+            }
+
         }
 
         // return custom sqon


### PR DESCRIPTION
## Summary

- Check for existence of SQON filter in `/download` endpoint to prevent error when selecting by identifier only.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-3069

## Type of Change

- [X] Bug fix

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

- Metadata that is downloaded by an identifier should only include the identifier in the metadata file.
