### PR TITLE
PILOT-4969: Replace name folder prefix with users prefix for parent paths

### DIFF
--- a/modules/server-filter/authFilter.js
+++ b/modules/server-filter/authFilter.js
@@ -268,7 +268,7 @@ const buildSQON = async (role_metadata, project_code, username) => {
         if (permissions['file_in_own_namefolder'].length !== 0) {
             for (const p of permissions['file_in_own_namefolder']) {
                 let owner_sqon = await readFile('./models/owner_sqon.json');
-                owner_sqon['content'][0]['content']['value'] = [`namefolder/${username}*`];
+                owner_sqon['content'][0]['content']['value'] = [`users/${username}*`];
                 owner_sqon['content'][1]['content']['value'] = [p];
                 base_sqon['content'][1]['content'].push(owner_sqon);
             }

--- a/modules/server-filter/models/others_sqon.json
+++ b/modules/server-filter/models/others_sqon.json
@@ -6,7 +6,7 @@
          "content":{
             "field":"parent_path",
             "value":[
-               "namefolder/*"
+               "users/*"
             ]
          }
       },

--- a/modules/server-filter/models/owner_sqon.json
+++ b/modules/server-filter/models/owner_sqon.json
@@ -6,7 +6,7 @@
          "content":{
             "field":"parent_path",
             "value":[
-               "namefolder/user*"
+               "users/user*"
             ]
          }
       },


### PR DESCRIPTION
## Summary

- Replace `namefolder/` prefix with `users/` prefix in parent paths for RBAC

Note: **Do not merge** until arranger elasticsearch index is updated to replace `namefolder/` prefix

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-4969

## Type of Change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

1. Arranger server filter should use `users/` prefix when implementing RBAC
2. Arranger server filter should return `users/` prefix in `parent_path` in response instead of `namefolder/`