### PR TITLE
PILOT-5112: Update metadata service call to use shared folder parent path

### DIFF
--- a/modules/server-filter/authFilter.js
+++ b/modules/server-filter/authFilter.js
@@ -116,6 +116,7 @@ const getProjectFolders = async (project_code = '', token = '',page = 0, data = 
             type: 'project_folder',
             container_code: project_code,
             status: 'ACTIVE',
+            parent_path: 'shared',
             page: page,
             page_size: METADATA_SERVICE_PAGE_SIZE
           },


### PR DESCRIPTION
## Summary

- Update call to metadata service to specify parent_path as a query param, in order to retrieve shared folders.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-5112

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

1. Create shared folder in project (or use existing shared folder in a project)
2. Add items to shared folder
3. Launch arranger faceted search interface and be able to filter by shared item type